### PR TITLE
Chat bot

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,3 +1,13 @@
 class WelcomeController < ApplicationController
   def index; end
+
+  def create 
+      @project = params[:project]
+      redirect_to result_path(project: @project)
+    end
+    
+    def result 
+      @project = params[:project]
+      @chat_results = ChatFacade.chat_request(@project)
+  end
 end

--- a/app/facades/chat_facade.rb
+++ b/app/facades/chat_facade.rb
@@ -1,0 +1,5 @@
+class ChatFacade 
+  def self.chat_request(project)
+    ChatService.chat_request(project)[:choices][0][:text]
+  end
+end

--- a/app/services/chat_service.rb
+++ b/app/services/chat_service.rb
@@ -1,0 +1,13 @@
+class ChatService 
+  def self.chat_request(project)
+    response = conn.get("/api/v1/chat_request")
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+
+  private 
+
+  def self.conn 
+    Faraday.new(url: "https://lend-a-toolza-be.onrender.com" )
+  end
+end

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -7,3 +7,11 @@
   <%= f.submit "Search" %>
 <% end %>
 
+
+<h2>What kind of project can we help you with?</h2>
+<%= form_with url: "/welcome", method: :post, local: true do |f| %>
+  <%= f.label :project %>
+  <%= f.text_field :project %>
+  <%= f.submit "Submit" %>
+<% end %>
+

--- a/app/views/welcome/result.html.erb
+++ b/app/views/welcome/result.html.erb
@@ -1,0 +1,11 @@
+<p>Chat Results: <%= @chat_results %></p>
+
+<h1>Search For Your Tools Buddy</h1>
+<%= form_with url: "/tools", method: :get, local: true do |f| %>
+  <%= f.label :name %>
+  <%= f.text_field :name %>
+  <%= f.label :location %>
+  <%= f.text_field :location %>
+
+  <%= f.submit "Search" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root "welcome#index"
-
+  post "/welcome", to: "welcome#create", as: :welcome
+  get '/result', to: 'welcome#result', as: :result
   get "/dashboard", to: "users#show", as: :dashboard
   resources :tools, only: [:new]
   get "/auth/google_oauth2/callback", to: "sessions#create"

--- a/spec/facades/chat_facade_spec.rb
+++ b/spec/facades/chat_facade_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require "./app/facades/chat_facade"
+
+RSpec.describe ChatFacade do
+  it "exists and returns chat text" do 
+    
+    chat_prompt = File.read('spec/fixtures/chat_response.json')
+    stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/chat_request")
+    .to_return(status: 200, body: chat_prompt, headers: {'Content-Type': 'application/json' })
+    
+    project = "deck"
+    
+    chat = ChatFacade.chat_request(project)
+    expect(chat).to be_a(String)
+    
+  end
+end

--- a/spec/facades/tool_facade_spec.rb
+++ b/spec/facades/tool_facade_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ToolFacade do
     tools_response = File.read('spec/fixtures/tools_index.json')
         stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/tools")
           .to_return(status: 200, body: tools_response)
-    # expect(tool_facade).to be_a(ToolFacade)
+
     tools = ToolFacade.get_tools
     expect(tools).to_not be_empty 
     expect(tools[0].name).to eq("Item Excepturi Rem")
@@ -20,4 +20,33 @@ RSpec.describe ToolFacade do
     expect(tools[0].status).to eq("unavailable")
     expect(tools[0].user_id).to eq("12")
   end
+
+  it 'returns tools based on keyword' do 
+    tools_search = File.read('spec/fixtures/hammer_search.json')
+    stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/search?name=hammer&location=IN")
+      .to_return(status: 200, body: tools_search, headers: { 'Content-Type': 'application/json' })
+
+    keyword = "hammer"
+    location = "IN"
+    search = ToolFacade.search_tools_by_keyword(keyword, location)
+    expect(search).to be_a(Array)
+    expect(search.first).to be_a(Tool)
+    expect(search.first.name).to eq("Kobalt Hammer")
+    expect(search.first.address).to eq("123 Sunnyside Dr, Lebanon, IN, 46052")
+    expect(search.first.borrower_id).to eq("nil")
+    expect(search.first.description).to eq("This bad boy will cover all your framing needs. Crooked stud? Nail popping up? Wanna just whack something? This hammer is the perfect tool!")
+    expect(search.first.id).to eq("1265")
+    expect(search.first.image).to eq("image.jpg")
+    expect(search.first.latitude).to eq("53.076645")
+    expect(search.first.longitude).to eq("10.3398")
+    expect(search.first.status).to eq("available")
+    expect(search.first.user_id).to eq("15")
+  end 
+
+  it "returns tools by id" do 
+    
+  end
+
+
+
 end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe "User can login" do
         expect(page).to have_content("Slammer Hammer")
 
       end
+
+      it "can take in user project to be consumed by backend chat bot" do 
+        chat_prompt = File.read('spec/fixtures/chat_response.json')
+        stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/chat_request")
+          .to_return(status: 200, body: chat_prompt, headers: {'Content-Type': 'application/json' })
+        
+        expect(page).to have_content("What kind of project can we help you with?")
+
+        fill_in :project, with: "deck"
+
+        click_button("Submit")
+
+        expect(current_path).to eq(result_path)
+        expect(page).to have_content("You will need a drill, a circular saw, a hammer, a level, a tape measure, a post hole digger, a framing square, a screwdriver, deck screws, and lag screws. You may also need decking boards, joist hangers, and other hardware specific to your project.")
+      end
     end
   end
 end

--- a/spec/features/welcome/result_spec.rb
+++ b/spec/features/welcome/result_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe "welcome result page" do 
+  it "displays chat results" do 
+    chat_prompt = File.read('spec/fixtures/chat_response.json')
+    stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/chat_request")
+      .to_return(status: 200, body: chat_prompt, headers: {'Content-Type': 'application/json' })
+    visit root_path
+    expect(page).to have_content("What kind of project can we help you with?")
+      
+    fill_in :project, with: "deck"
+      
+    click_button("Submit")
+    expect(current_path).to eq(result_path)
+    expect(page).to have_content("You will need a drill, a circular saw, a hammer, a level, a tape measure, a post hole digger, a framing square, a screwdriver, deck screws, and lag screws. You may also need decking boards, joist hangers, and other hardware specific to your project.")
+  end
+
+  it "has secondary tool search after chatbot results" do 
+    visit root_path 
+
+    tools_search = File.read('spec/fixtures/hammer_search.json')
+    stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/search?name=hammer&location=IN")
+      .to_return(status: 200, body: tools_search, headers: { 'Content-Type': 'application/json' })
+
+    fill_in :name, with: "hammer"
+    fill_in :location, with: "IN"
+
+    click_button('Search')
+
+    expect(current_path).to eq("/tools")
+    expect(page).to have_content("Slammer Hammer")
+  end
+end

--- a/spec/fixtures/chat_response.json
+++ b/spec/fixtures/chat_response.json
@@ -1,0 +1,7 @@
+{
+  "choices": [
+    {
+      "text": "You will need a drill, a circular saw, a hammer, a level, a tape measure, a post hole digger, a framing square, a screwdriver, deck screws, and lag screws. You may also need decking boards, joist hangers, and other hardware specific to your project."
+    }
+  ]
+}

--- a/spec/fixtures/hammer_search.json
+++ b/spec/fixtures/hammer_search.json
@@ -9,10 +9,10 @@
         "image": "image.jpg",
         "status": "available",
         "user_id": "15",
-        "location": "123 Sunnyside Dr, Lebanon, IN, 46052",
+        "address": "123 Sunnyside Dr, Lebanon, IN, 46052",
         "latitude": "53.076645",
         "longitude": "10.3398",
-        "borrow_id": "nil"
+        "borrower_id": "nil"
       }
     },
     {
@@ -24,10 +24,10 @@
         "image": "image.jpg",
         "status": "available",
         "user_id": "15",
-        "location": "123 Sunnyside Dr, Lebanon, IN, 46052",
+        "address": "123 Sunnyside Dr, Lebanon, IN, 46052",
         "latitude": "53.076645",
         "longitude": "10.3398",
-        "borrow_id": "13"
+        "borrower_id": "13"
       }
     }
   ]

--- a/spec/services/chat_service_spec.rb
+++ b/spec/services/chat_service_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe ChatService do 
+  it 'returns openAI chat response from given project prompt' do 
+    chat_prompt = File.read('spec/fixtures/chat_response.json')
+    stub_request(:get, "https://lend-a-toolza-be.onrender.com/api/v1/chat_request")
+      .to_return(status: 200, body: chat_prompt, headers: {'Content-Type': 'application/json' })
+
+    project = "deck"
+
+    chat = ChatService.chat_request(project)
+    expect(chat).to be_a(Hash)
+    expect(chat[:choices][0][:text]).to eq("You will need a drill, a circular saw, a hammer, a level, a tape measure, a post hole digger, a framing square, a screwdriver, deck screws, and lag screws. You may also need decking boards, joist hangers, and other hardware specific to your project.")
+  end
+end

--- a/spec/services/tools_service_spec.rb
+++ b/spec/services/tools_service_spec.rb
@@ -74,6 +74,4 @@ RSpec.describe ToolsService do
     tool_data = search[:data].first
     expect(tool_data[:attributes][:name]).to eq("Kobalt Hammer")
   end 
-
-
 end


### PR DESCRIPTION
this pr establishes the chat bot api in the front end. I had to make a new page /welcome/results the user will be sent from the welcome page to this page after they interact with the chat bot. The results will be on the page as well as a duplicate search form which has the same functionality as the original. I also fleshed out a few more tests in our services. 
This also changes the fields for location to address and borrow_id to borrower_id across the front end to coordinate with the specifications of the backend db